### PR TITLE
bug fix: crop params get messy since array delete_at i+1 deletes wrong e...

### DIFF
--- a/lib/rails_admin_jcrop/asset_engine/paperclip.rb
+++ b/lib/rails_admin_jcrop/asset_engine/paperclip.rb
@@ -37,8 +37,8 @@ module Paperclip
       if @attachment.instance.rails_admin_cropping?
         ary = super
         if i = ary.index('-crop')
-          ary.delete_at i
           ary.delete_at i+1
+          ary.delete_at i
         end
         ['-crop', crop_params] + ary
       else


### PR DESCRIPTION
this might help with Issue https://github.com/janx/rails_admin_jcrop/issues/4, it worked for me.
