### PR TITLE
Support RailsAdmin Property class

### DIFF
--- a/lib/rails_admin_jcrop/rails_admin.rb
+++ b/lib/rails_admin_jcrop/rails_admin.rb
@@ -30,8 +30,8 @@ module RailsAdmin
 end
 
 RailsAdmin::Config::Fields.register_factory do |parent, properties, fields|
-  if properties[:name] == :jcrop
-    fields << RailsAdmin::Config::Fields::Types::Jcrop.new(parent, properties[:name], properties)
+  if (properties.respond_to?(:name) ? properties.name : properties[:name]) == :jcrop
+    fields << RailsAdmin::Config::Fields::Types::Jcrop.new(parent, :jcrop, properties)
     true
   else
     false


### PR DESCRIPTION
RailsAdmin recently introduced `Property` class and stopped using old hashy-syntax.
cf. https://github.com/sferik/rails_admin/commit/875c9ba7c18665f768bc48f118c0e9d0c74cb81a
This PR accommodates rails_admin_jcrop to the change, while maintaining backward compatibility.

Refs. sferik/rails_admin#1953
