### PR TITLE
compatibility with rails_admin 0.6.6

### DIFF
--- a/app/assets/javascripts/rails_admin/ra.jcrop.js
+++ b/app/assets/javascripts/rails_admin/ra.jcrop.js
@@ -62,6 +62,7 @@
       }).html(cancelButtonText);
 
       dialog.find('.save-action').unbind().click(function(){
+        $(this).addClass('disabled');
         form.submit();
         return false;
       }).html(saveButtonText);

--- a/app/assets/javascripts/rails_admin/ra.jcrop.js
+++ b/app/assets/javascripts/rails_admin/ra.jcrop.js
@@ -5,7 +5,7 @@
       var widget = this;
       var dom_widget = widget.element;
 
-      var thumbnailLink = dom_widget.find('img[class^=img-]').parent();
+      var thumbnailLink = dom_widget.find('img.img-polaroid, img.img-thumbnail').first().parent(); // workaround for different bootstrap versions using a different class for thumbnails
       thumbnailLink.unbind().bind("click", function(e){
         widget._bindModalOpening(e, dom_widget.find('a.jcrop_handle').data('link'));
         return false;

--- a/app/assets/javascripts/rails_admin/ra.jcrop.js
+++ b/app/assets/javascripts/rails_admin/ra.jcrop.js
@@ -115,7 +115,7 @@
             backdrop: true,
             show: true
           })
-          .on('hidden', function(){
+          .on('hidden.bs.modal', function(){
             widget.dialog.remove();   // We don't want to reuse closed modals
             widget.dialog = null;
           });

--- a/app/assets/javascripts/rails_admin/ra.jcrop.js
+++ b/app/assets/javascripts/rails_admin/ra.jcrop.js
@@ -109,7 +109,7 @@
     _getModal: function() {
       var widget = this;
       if (!widget.dialog) {
-          widget.dialog = $('<div id="modal" class="modal fade"><div class="modal-header"><a href="#" class="close" data-dismiss="modal">&times;</a><h3 class="modal-header-title">...</h3></div><div class="modal-body">...</div><div class="modal-footer"><a href="#" class="btn cancel-action">...</a><a href="#" class="btn btn-primary save-action">...</a></div></div>');
+          widget.dialog = $('<div id="modal" class="modal fade"><div class="modal-dialog"><div class="modal-content"><div class="modal-header"><a href="#" class="close" data-dismiss="modal">&times;</a><h3 class="modal-header-title">...</h3></div><div class="modal-body">...</div><div class="modal-footer"><a href="#" class="btn cancel-action">...</a><a href="#" class="btn btn-primary save-action">...</a></div></div></div></div>');
           widget.dialog.modal({
             keyboard: true,
             backdrop: true,

--- a/app/assets/javascripts/rails_admin/ra.jcrop.js
+++ b/app/assets/javascripts/rails_admin/ra.jcrop.js
@@ -5,7 +5,7 @@
       var widget = this;
       var dom_widget = widget.element;
 
-      var thumbnailLink = dom_widget.find('img.img-polaroid').parent();
+      var thumbnailLink = dom_widget.find('img[class^=img-]').parent();
       thumbnailLink.unbind().bind("click", function(e){
         widget._bindModalOpening(e, dom_widget.find('a.jcrop_handle').data('link'));
         return false;

--- a/app/assets/javascripts/rails_admin/ra.jcrop.js
+++ b/app/assets/javascripts/rails_admin/ra.jcrop.js
@@ -109,7 +109,7 @@
     _getModal: function() {
       var widget = this;
       if (!widget.dialog) {
-          widget.dialog = $('<div id="modal" class="modal fade"><div class="modal-dialog"><div class="modal-content"><div class="modal-header"><a href="#" class="close" data-dismiss="modal">&times;</a><h3 class="modal-header-title">...</h3></div><div class="modal-body">...</div><div class="modal-footer"><a href="#" class="btn cancel-action">...</a><a href="#" class="btn btn-primary save-action">...</a></div></div></div></div>');
+          widget.dialog = $('<div id="modal" class="modal fade"><div class="modal-dialog modal-lg"><div class="modal-content"><div class="modal-header"><a href="#" class="close" data-dismiss="modal">&times;</a><h3 class="modal-header-title">...</h3></div><div class="modal-body">...</div><div class="modal-footer"><a href="#" class="btn cancel-action">...</a><a href="#" class="btn btn-primary save-action">...</a></div></div></div></div>');
           widget.dialog.modal({
             keyboard: true,
             backdrop: true,

--- a/app/controllers/rails_admin/jcrop_controller.rb
+++ b/app/controllers/rails_admin/jcrop_controller.rb
@@ -40,10 +40,12 @@ module RailsAdmin
 
       @image_tag_options[:'data-geometry'] = geometry(@file_path).join(",")
 
+      @form_options[:'style'] = 'overflow: auto;'
+
       if @fit_image_geometry
         fit_image_geometry = fit_image_geometry(@file_path)
 
-        @form_options[:'style'] = "margin-left: #{375 - (fit_image_geometry[0]/2) - 15}px;"
+        @form_options[:'style'] << "margin-left: #{375 - (fit_image_geometry[0]/2) - 15}px;"
 
         @image_tag_options[:style] = ""
         @image_tag_options[:style] << "width: #{fit_image_geometry[0]}px !important;"

--- a/app/controllers/rails_admin/jcrop_controller.rb
+++ b/app/controllers/rails_admin/jcrop_controller.rb
@@ -8,6 +8,12 @@ module RailsAdmin
 
     helper_method :abstract_model, :geometry
 
+    # These numbers are based on bootstrap defaults
+    # https://github.com/twbs/bootstrap-sass/blob/master/assets/stylesheets/bootstrap/_variables.scss
+    # width: $modal-lg(900px) - 2 * border(1px) - 2 * $modal-inner-padding(15px)
+    # height: width * 9/16 (16:9 format)
+    FIT_IMAGE_DIMENSIONS = [868, 489]
+
     def edit
       @form_options = {}
       @form_options[:method] = :put
@@ -45,7 +51,7 @@ module RailsAdmin
       if @fit_image_geometry
         fit_image_geometry = fit_image_geometry(@file_path)
 
-        @form_options[:'style'] << "margin-left: #{375 - (fit_image_geometry[0]/2) - 15}px;"
+        @form_options[:'style'] << "margin-left: #{(FIT_IMAGE_DIMENSIONS[0] - fit_image_geometry[0])/2}px;"
 
         @image_tag_options[:style] = ""
         @image_tag_options[:style] << "width: #{fit_image_geometry[0]}px !important;"
@@ -86,7 +92,7 @@ module RailsAdmin
     end
 
     def get_fit_image
-      @fit_image = params[:fit_image] == "true" ? true : false
+      @fit_image_geometry = params[:fit_image] == "true" ? true : false
     end
 
     def get_field
@@ -100,8 +106,7 @@ module RailsAdmin
 
     def fit_image_geometry(image_path)
       image = MiniMagick::Image.open(image_path)
-      # Magic number origin: https://github.com/janx/rails_admin_jcrop/pull/2
-      image.resize "720x400"
+      image.resize FIT_IMAGE_DIMENSIONS.join('x')
       [image[:width], image[:height]]
     end
 

--- a/rails_admin_jcrop.gemspec
+++ b/rails_admin_jcrop.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib,vendor}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.markdown"]
 
-  s.add_dependency "rails", ">= 3.0.0"
-  s.add_dependency "rails_admin", ">= 0.3.0"
+  s.add_dependency "rails", "~> 4.0"
+  s.add_dependency "rails_admin", ">= 0.6.6"
   s.add_dependency "mini_magick"
 end


### PR DESCRIPTION
Starting version 0.6.6, rails_admin embeds [bootstrap 3](https://github.com/sferik/rails_admin/tree/v0.6.6/app/assets/stylesheets/rails_admin/bootstrap). This affects the html code for the modal dialog as well as the javascript events which use namespaces now. See http://getbootstrap.com/migration/#notes

This PR also fixes the fit_image option.