### PR TITLE
Add support for carrierwave-aws storage

### DIFF
--- a/app/controllers/rails_admin/jcrop_controller.rb
+++ b/app/controllers/rails_admin/jcrop_controller.rb
@@ -19,7 +19,7 @@ module RailsAdmin
       #Condition for Carrierwave.
       if @object.send(@field).class.to_s =~ /Uploader/
 
-        if @object.send(@field)._storage.to_s =~ /Fog/
+        if @object.send(@field)._storage.to_s =~ /Fog|AWS/
 
           @file_path=@object.send(@field).url
         else


### PR DESCRIPTION
Adds a simple check to support the carrierwave-aws gem (https://github.com/sorentwo/carrierwave-aws) in addition to fog for remotely stored images.